### PR TITLE
fix: silence CodeQL py/mixed-returns in _relay_state

### DIFF
--- a/src/proconip/definitions.py
+++ b/src/proconip/definitions.py
@@ -256,11 +256,11 @@ class DataObject:
         """
         if self._value == 0:
             return "Auto (off)"
-        if self._value == 1:
+        elif self._value == 1:
             return "Auto (on)"
-        if self._value == 2:
+        elif self._value == 2:
             return "Off"
-        if self._value == 3:
+        elif self._value == 3:
             return "On"
         raise ValueError(f"Unexpected relay value {self._value}")
 

--- a/src/proconip/definitions.py
+++ b/src/proconip/definitions.py
@@ -254,17 +254,15 @@ class DataObject:
             ValueError: If `self._value` is not one of the four valid relay
                 states (0, 1, 2, 3). Indicates a malformed CSV payload.
         """
-        match self._value:
-            case 0:
-                return "Auto (off)"
-            case 1:
-                return "Auto (on)"
-            case 2:
-                return "Off"
-            case 3:
-                return "On"
-            case _:
-                raise ValueError(f"Unexpected relay value {self._value}")
+        if self._value == 0:
+            return "Auto (off)"
+        if self._value == 1:
+            return "Auto (on)"
+        if self._value == 2:
+            return "Off"
+        if self._value == 3:
+            return "On"
+        raise ValueError(f"Unexpected relay value {self._value}")
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Summary

- Rewrites `DataObject._relay_state` from `match`/`case` to a flat `if`/`elif` chain ending in `raise ValueError(...)`.
- Silences [CodeQL alert #3](https://github.com/ylabonte/proconip-pypi/security/code-scanning/3) (\`py/mixed-returns\`).
- Aligns with the guidance already in [CLAUDE.md](https://github.com/ylabonte/proconip-pypi/blob/main/CLAUDE.md) — we'd flagged this exact pattern as a known CodeQL false-positive elsewhere in the overhaul, but missed this one occurrence.

## Why CodeQL flagged it

The original `match` ended in `case _: raise ValueError(...)`, so the function always returns or raises and is in fact exhaustive. CodeQL's `py/mixed-returns` analyzer doesn't track exhaustiveness through `match` and reads the (impossible) fall-off-end path as an implicit `None` return mixed with the explicit string returns. Severity: `note`.

## Behavior

Unchanged. Same four state strings for `self._value` 0..3, same `ValueError` for anything else. Existing regression coverage in `tests/test_definitions.py` exercises all four valid states plus the error branch.

## Test plan

- [x] `pytest` — 92 passed, 93.67% coverage
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy src` — clean
- [ ] CI: `lint`, `test`, `codeql` workflows pass on this PR
- [ ] After merge: re-tag \`v2.0.0\` on the new \`main\` HEAD and update the v2.0.0 draft release target

🤖 Generated with [Claude Code](https://claude.com/claude-code)