### PR TITLE
fix(lint): RET505 in _relay_state (revert elif → if)

### DIFF
--- a/src/proconip/definitions.py
+++ b/src/proconip/definitions.py
@@ -256,11 +256,11 @@ class DataObject:
         """
         if self._value == 0:
             return "Auto (off)"
-        elif self._value == 1:
+        if self._value == 1:
             return "Auto (on)"
-        elif self._value == 2:
+        if self._value == 2:
             return "Off"
-        elif self._value == 3:
+        if self._value == 3:
             return "On"
         raise ValueError(f"Unexpected relay value {self._value}")
 


### PR DESCRIPTION
## Summary

- Reverts the four `elif` branches in `DataObject._relay_state` back to plain `if`s.
- Fixes ruff [RET505](https://docs.astral.sh/ruff/rules/unnecessary-elif-after-return-statement/) ("Unnecessary \`elif\` after \`return\` statement"), which is currently failing on \`main\` and blocking the v2.0.0 PyPI publish workflow.

## Background

In PR #75 we rewrote `_relay_state` from `match`/`case` to `if`/`if`/.../`raise` to silence CodeQL's `py/mixed-returns` false positive (alert #3). A subsequent Copilot autofix commit on \`main\` (\`4be8a90\`) replaced those plain `if`s with `elif`s, which CodeQL was happy with but ruff now flags. The `if`-only form satisfies both linters.

Failing lint run that motivated this fix:
<https://github.com/ylabonte/proconip-pypi/actions/runs/25635199188>

## Impact on the v2.0.0 release

The v2.0.0 GitHub Release is currently published, but the publish workflow was *cancelled* (lint dependency failed), so PyPI never received the artifact. After this PR merges:

1. The \`v2.0.0\` tag will be force-updated to the new \`main\` HEAD (lint-clean code, identical behavior).
2. The release will be toggled draft → published to re-fire \`python-publish.yml\`.

## Behavior

Unchanged. Same four state strings for `self._value` 0..3, same `ValueError` for anything else.

## Test plan

- [x] `pytest` — 92 passed, 93.67% coverage
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy src` — clean
- [ ] CI: `lint`, `test`, `codeql` workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)