### PR TITLE
ci: scope test/lint concurrency groups so workflow_call doesn't collide

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: test-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Scopes the \`concurrency.group\` of \`test.yml\` and \`lint.yml\` to a hardcoded prefix (\`test-…\` / \`lint-…\`) instead of \`\${{ github.workflow }}\`. Unblocks the v2.0.0 PyPI publish workflow.

## Root cause

When \`python-publish.yml\` calls \`test.yml\` and \`lint.yml\` via \`workflow_call\`, GitHub's \`\${{ github.workflow }}\` context value resolves to the **parent** workflow's name in both children. So both reusable workflows compute the same concurrency group:

\`\`\`
PyPI Package Release-refs/tags/v2.0.0
\`\`\`

With \`cancel-in-progress: true\`, the two children fight each other inside the parent: lint wins the race and test gets cancelled with the message _"Canceling since a higher priority waiting request for PyPI Package Release-refs/tags/v2.0.0 exists"_. \`publish\` then skips because \`needs: [test, lint]\` failed. \`gh run rerun\` reproduces the cancellation deterministically.

## Fix

\`\`\`diff
 concurrency:
-  group: \${{ github.workflow }}-\${{ github.ref }}
+  group: test-\${{ github.ref }}        # in test.yml
+  group: lint-\${{ github.ref }}        # in lint.yml
   cancel-in-progress: true
\`\`\`

Each reusable workflow now has its own concurrency group regardless of caller. Push/PR cancel-old-run behavior is preserved.

## Impact on the v2.0.0 release

The v2.0.0 GitHub Release is currently published, but the publish workflow has been cancelled twice on \`d144b9e\`. After this PR merges:

1. The \`v2.0.0\` tag will be force-updated to the new \`main\` HEAD.
2. The publish workflow will be re-fired (toggle release draft↔published, or \`gh run rerun\`).

## Test plan

- [x] Local: no test impact — pure CI config change
- [ ] CI on this PR: \`lint\` and \`test\` should run in parallel without cancelling each other (this PR itself exercises only the push/PR triggers, not workflow_call — but verifies syntax)
- [ ] After merge: re-fire \`python-publish.yml\` and confirm \`test\` no longer self-cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)