### PR TITLE
ci(docs): drop redundant release trigger that always fails to deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ name: Documentation
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Removes \`release: types: [published]\` from \`docs.yml\`'s trigger list. Eliminates a duplicate build and a failing deploy that fires on every release.

## Why

The Documentation workflow triggers on:
\`\`\`yaml
on:
  push:
    branches: [main]
  release:
    types: [published]
  workflow_dispatch:
\`\`\`

Every release is cut from a commit that's already on \`main\`, so the \`push\` trigger has already rebuilt and deployed the docs by the time a release fires. The \`release\`-triggered run is therefore redundant.

It's also actively broken: the \`github-pages\` environment is configured to only deploy from the default branch (\`main\`), but the release event runs on \`refs/tags/v…\`. The \`deploy\` job is rejected by the environment before any step runs — 2-second runtime, empty step list, red ✗ on every release.

Failing run that motivated this fix:
<https://github.com/ylabonte/proconip-pypi/actions/runs/25635414002>

## Behavior after this PR

- Push to \`main\` → docs rebuild and deploy (unchanged)
- \`workflow_dispatch\` → manual rebuild (unchanged)
- Release published → no docs run (was failing; now nothing happens, which is correct because the docs were already updated by the push that preceded the tag)

## Test plan

- [x] Diff inspection — only the \`release\` trigger lines removed
- [ ] CI on this PR: existing checks still pass
- [ ] After merge: confirm next release does not trigger a Documentation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)