### PR TITLE
chore(deps): tidy dependabot groups and commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
     assignees:
       - ylabonte
+    commit-message:
+      prefix: "ci"
     groups:
       actions:
         patterns:
@@ -27,13 +29,14 @@ updates:
         patterns:
           - "aiohttp"
           - "yarl"
-          - "multidict"
-          - "propcache"
       dev-tools:
         patterns:
           - "ruff"
           - "mypy"
           - "pre-commit"
           - "pytest*"
-          - "pytest-*"
           - "aioresponses"
+      docs-tools:
+        patterns:
+          - "mkdocs*"
+          - "mkdocstrings*"


### PR DESCRIPTION
## Summary
- Drop dead patterns from pip groups: `multidict` and `propcache` are transitive (not declared in `pyproject.toml`), and `pytest-*` is already matched by the `pytest*` glob.
- Add a `docs-tools` group so `mkdocs*` / `mkdocstrings*` updates land as one PR instead of four.
- Add `commit-message.prefix: "ci"` for the github-actions ecosystem, mirroring the existing `deps` / `deps-dev` prefixes used for pip.

No behavioral change to the auto-merge workflow.

## Test plan
- [ ] CI passes (lint, test, CodeQL)
- [ ] Next dependabot run produces a single grouped PR per ecosystem group, with the new commit prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)