### PR TITLE
ci: add ylabonte/github-actions-updater and tighten action update flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - ylabonte
-    commit-message:
-      prefix: "ci"
-    groups:
-      actions:
-        patterns:
-          - "*"
-
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   automerge:
     name: Enable auto-merge
+    if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge (rebase)

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -1,0 +1,30 @@
+name: Update GitHub Actions
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Mondays, 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ylabonte/github-actions-updater@v1
+        id: ghau
+        with:
+          write: true
+          commit: true
+      - uses: peter-evans/create-pull-request@v6
+        if: steps.ghau.outputs.changes > 0
+        with:
+          branch: chore/update-github-actions
+          title: 'chore(deps): update GitHub Actions'
+          body: |
+            Automated update of outdated GitHub Actions references.
+            See the commit message for the per-action breakdown.
+          delete-branch: true


### PR DESCRIPTION
## Summary

Three small, related changes to align this repo's action-update flow with the new strategy (ghau-driven, scoped auto-merge, prepping for the changesets release migration that's coming next):

1. **Add `update-actions.yml`** — runs `ylabonte/github-actions-updater@v1` weekly (Mondays 08:00 UTC) plus on-demand via `workflow_dispatch`. When ghau detects outdated action references, `peter-evans/create-pull-request@v6` opens a `chore/update-github-actions` PR with the diff.

2. **Drop the `github-actions` ecosystem from `dependabot.yml`** — ghau is now the single source of truth for action version bumps. The `pip` ecosystem (with its existing groupings: `aiohttp-stack`, `dev-tools`, `docs-tools`) is untouched.

3. **Scope `enable-auto-merge.yml` to bot PRs** — adds `if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]'` at the job level. Human PRs no longer auto-merge. This is required prep for the upcoming changesets migration: the auto-opened "Version Packages" PR must be human-reviewed before it lands and triggers a release.

## Why now

- ghau is more responsive to action releases than dependabot's weekly cadence
- One mechanism = no duplicate PRs racing each other
- Broad auto-merge becomes unsafe once we have a release-PR pattern (next migration)

## Test plan

- [ ] CI green (lint, test, codeql, docs)
- [ ] After merge: `gh workflow run "Update GitHub Actions"` succeeds and either reports no changes or opens a `chore/update-github-actions` PR
- [ ] After merge: open a non-bot PR and confirm `enable-auto-merge.yml` skips it (no auto-merge enabled)
- [ ] Dependabot's next weekly run produces only `pip` PRs (no github-actions PRs)

## Coming next

PR 2 will migrate the release flow from manual tag + release-drafter to changesets, mirroring `../github-actions-updater`. Requires a small one-time GitHub App setup before it can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)