### PR TITLE
fix(deps): revert mechanical aiohttp/yarl runtime pin bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,19 @@ updates:
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
+    # aiohttp & yarl are runtime deps with hand-set floors aligned to
+    # HA Core. Only allow major + security updates so Dependabot cannot
+    # silently tighten the floors again (regression: PR #73 / 9f4ca31).
+    ignore:
+      - dependency-name: "aiohttp"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "yarl"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
-      aiohttp-stack:
-        patterns:
-          - "aiohttp"
-          - "yarl"
       dev-tools:
         patterns:
           - "ruff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "aiohttp>=3.13.5,<4",
-    "yarl>=1.23.0,<2",
+    "aiohttp>=3.10,<4",
+    "yarl>=1.9,<2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

Revert the mechanical Dependabot floor bump landed in [9f4ca31](https://github.com/ylabonte/proconip-pypi/commit/9f4ca31) (PR #73), restoring the v2.0.0 runtime floors:

- `aiohttp>=3.13.5,<4` -> `aiohttp>=3.10,<4`
- `yarl>=1.23.0,<2` -> `yarl>=1.9,<2`

No code change in the library - the actual aiohttp/yarl surface (`BasicAuth`, `ClientSession.get`/`post`, `ClientResponse.status`/`raise_for_status`/`text`, `ClientError`, `URL.with_path`) is long-stable. Independently verified: **151/151 tests pass with `aiohttp==3.10.11` and `yarl<2` installed.**

## Why now

The tight floors gratuitously prevent downstream `proconip-hass` HACS releases from targeting older HA Core lines. After this lands, the integration's HA floor can drop from 2026.5.2 to whatever HA Core release first required Python 3.13.

## Recurrence prevention

Second commit narrows the Dependabot pip config: drops the `aiohttp-stack` group, adds an `ignore:` block filtering minor+patch updates on `aiohttp` and `yarl`. Only majors (rare) and security advisories will reach a PR for these two going forward.

## Test plan

- [x] `pytest -q` against this branch (current pins) - 151/151 pass, coverage 94.26%
- [x] `pytest -q` after `pip install 'aiohttp==3.10.11' 'yarl<2'` - 151/151 pass (verified in a separate session)
- [ ] CI `lint.yml`, `test.yml`, `codeql.yml`, `docs.yml` green on the PR

## Release

On squash-merge, release-please will pick up the `fix:` Conventional Commit and open a `chore(main): release 2.1.1` PR.