### PR TITLE
ci: prevent tag pushes from racing python-publish reusable calls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+    branches: ["**"]
   pull_request:
   workflow_call:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: ["**"]
   pull_request:
   workflow_call:
 


### PR DESCRIPTION
## Summary

Caught during the v2.1.1 release: `python-publish.yml` was cancelled 2 seconds after the GitHub Release was published, before its `publish` step could run. PyPI 2.1.1 only landed after a manual `gh run rerun`.

Root cause: `test.yml` and `lint.yml` declare both

- `on: push` (with no branch filter, so they also fire on tag pushes), and
- `on: workflow_call` (so `python-publish.yml` can invoke them as needed checks),

and they share concurrency group `test-${{ github.ref }}` / `lint-${{ github.ref }}` with `cancel-in-progress: true`. When release-please merges its release PR:

1. Tag `vX.Y.Z` is pushed -> standalone `Test` and `Lint` runs queue under `test-refs/tags/vX.Y.Z` / `lint-refs/tags/vX.Y.Z`.
2. The GitHub Release is published at the same instant -> `python-publish.yml` fires, and its reusable `uses: ./.github/workflows/test.yml` / `uses: ./.github/workflows/lint.yml` invocations inherit the same `github.ref` and join the same concurrency groups.
3. One set wins and the other gets cancelled. On v2.1.1 the publish's reusable jobs lost; see [run 26069623922](https://github.com/ylabonte/proconip-pypi/actions/runs/26069623922).

## Fix

Limit the standalone `push:` trigger on `test.yml` and `lint.yml` to branch refs (`branches: ["**"]`). Tag pushes no longer spawn standalone Test/Lint runs, so `python-publish.yml`'s reusable calls run unopposed in the concurrency group. PR and `workflow_call` coverage is unchanged; every branch push still triggers full test+lint.

## Test plan

- [ ] CI `lint`, `test (3.13)`, `CodeQL`, `Documentation` green on this PR (these all use `pull_request:` triggers, which this PR doesn't touch)
- [ ] Next release after merge: `python-publish.yml` runs end-to-end on the `release: published` event without a manual rerun

## Release impact

`ci:` is a no-bump type in `.release-please-config.json`, so this won't open a release PR on its own.