### PR TITLE
fix: correct inverted NTP fault bit-16 label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,17 @@ dependencies = [
 
 [dependency-groups]
 dev = ["ruff", "mypy", "pre-commit"]
-test = ["pytest", "pytest-asyncio", "pytest-cov", "aioresponses"]
+test = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "aioresponses",
+    # aioresponses 0.7.8 can't build mocked responses against aiohttp 3.14+
+    # (ClientResponse gained a required `stream_writer` kwarg), which breaks
+    # the whole test_api suite. Pin tests to the 3.13.x line HA Core ships.
+    # TODO: lift this cap once a compatible aioresponses release lands.
+    "aiohttp<3.14",
+]
 docs = [
     "mkdocs",
     "mkdocs-material",

--- a/src/proconip/definitions.py
+++ b/src/proconip/definitions.py
@@ -55,14 +55,16 @@ RESET_ROOT_CAUSE = {
 }
 
 # Lookup table mapping NTP fault state codes to human labels. Values 1, 2 and
-# 4 are severity bit flags that may also appear in combination; the bit 65536
-# indicates "NTP synchronisation reached" and is set independently.
+# 4 are severity bit flags (the green/yellow/red GUI warning lamps) that may
+# also appear in combination. Bit 65536 (bit 16) is set independently and
+# indicates an NTP fault: when set, the controller has not received a time
+# from its NTP server (clear means the clock is in sync).
 NTP_FAULT_STATE = {
     0: "n.a.",
     1: "Logfile (GUI warning, green)",
     2: "Warning (GUI warning, yellow)",
     4: "Error (GUI warning, red)",
-    65536: "NTP available",
+    65536: "NTP fault (no time received)",
 }
 
 
@@ -534,7 +536,8 @@ class GetStateData:
     def ntp_fault_state(self) -> int:
         """Numeric NTP fault state. Decode with `NTP_FAULT_STATE` or
         `get_ntp_fault_state_as_str`. Bits 0/1/2 indicate severity (logfile,
-        warning, error); bit 16 indicates "NTP available"."""
+        warning, error); bit 16 set indicates an NTP fault — no time received
+        from the NTP server (clear means the clock is in sync)."""
         return self._ntp_fault_state
 
     @property

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -105,7 +105,7 @@ def test_get_state_ntp_fault_state(get_state_data: GetStateData) -> None:
         (1, "Logfile (GUI warning, green)"),
         (2, "Warning (GUI warning, yellow)"),
         (4, "Error (GUI warning, red)"),
-        (65536, "NTP available"),
+        (65536, "NTP fault (no time received)"),
         # composite: bits 1+2 → highest = 2
         (3, "Warning (GUI warning, yellow)"),
         # composite: bits 1+4 → highest = 4


### PR DESCRIPTION
## What

Bit 16 (`65536`) of `ntp_fault_state` (parsed from `SYSINFO[4]`) was labeled
`"NTP available"`, with the comment/docstring describing it as "NTP
synchronisation reached". That polarity is inverted — bit 16 *set* means the
controller received **no** time from its NTP server. This relabels it to
`"NTP fault (no time received)"` and corrects the comment + `ntp_fault_state`
property docstring.

## Why

Per the pooldigital.de admin (controller vendor): bit 16 = 1 → no time from an
NTP server; = 0 → all good. Corroborated by an error-free hardware dump where
`SYSINFO[4] = 0` (bit 16 clear) on a healthy unit — if `65536` meant
"available", a healthy synced controller would read `65536`, not `0`. Full
evidence in #90.

## Tests

- Updated the `65536` case in `test_get_ntp_fault_state_as_str_parametrized`.
- `pytest`: 151 passed, 94% coverage. `ruff check`, `ruff format --check`,
  `mypy src` all clean.

Closes #90
